### PR TITLE
为JM增加了专属的关键词屏蔽方法，修复历史记录添加问题。

### DIFF
--- a/lib/base.dart
+++ b/lib/base.dart
@@ -147,6 +147,9 @@ class Appdata {
 
   ///屏蔽的关键词
   List<String> blockingKeyword = [];
+  
+  ///禁漫天堂专用屏蔽关键词
+  List<String> jmBlockingKeyword = [];
 
   ///是否第一次使用的判定, 用于显示提示
   List<String> firstUse = [
@@ -216,6 +219,7 @@ class Appdata {
     var s = await SharedPreferences.getInstance();
     await updateSettings();
     await s.setStringList("blockingKeyword", blockingKeyword);
+    await s.setStringList("jmBlockingKeyword", jmBlockingKeyword);
     await s.setStringList("firstUse", firstUse);
   }
 
@@ -226,6 +230,7 @@ class Appdata {
       searchHistory = s.getStringList("search") ?? [];
       favoriteTags = (s.getStringList("favoriteTags") ?? []).toSet();
       blockingKeyword = s.getStringList("blockingKeyword") ?? [];
+      jmBlockingKeyword = s.getStringList("jmBlockingKeyword") ?? [];
       if (s.getStringList("firstUse") != null) {
         var st = s.getStringList("firstUse")!;
         for (int i = 0; i < st.length; i++) {

--- a/lib/network/eh_network/eh_main_network.dart
+++ b/lib/network/eh_network/eh_main_network.dart
@@ -844,11 +844,6 @@ class EhNetwork {
   ///搜索e-hentai
   Future<Res<Galleries>> search(String keyword,
       {int? fCats, int? startPages, int? endPages, int? minStars}) async {
-    if (keyword != "") {
-      appdata.searchHistory.remove(keyword);
-      appdata.searchHistory.add(keyword);
-      appdata.writeHistory();
-    }
     keyword = keyword.replaceAll(RegExp(r"\s+"), " ").trim();
     if(keyword.contains(" | ")) {
       var keywords = _splitKeyword(keyword);

--- a/lib/network/hitomi_network/hitomi_main_network.dart
+++ b/lib/network/hitomi_network/hitomi_main_network.dart
@@ -120,9 +120,6 @@ class HiNetwork{
   ///搜索Hitomi
   Future<Res<List<int>>> search(String keyword) async{
     await getProxy();
-    appdata.searchHistory.remove(keyword);
-    appdata.searchHistory.add(keyword);
-    appdata.writeHistory();
     try{
       var searchEngine = HitomiSearch(keyword);
       var res = await searchEngine.search();

--- a/lib/network/htmanga_network/htmanga_main_network.dart
+++ b/lib/network/htmanga_network/htmanga_main_network.dart
@@ -238,11 +238,6 @@ class HtmangaNetwork {
   }
 
   Future<Res<List<HtComicBrief>>> search(String keyword, int page) {
-    if (keyword != "") {
-      appdata.searchHistory.remove(keyword);
-      appdata.searchHistory.add(keyword);
-      appdata.writeHistory();
-    }
     Future.delayed(const Duration(milliseconds: 300),
             () => StateController.find<PreSearchController>().update())
         .onError((error, stackTrace) => null);

--- a/lib/network/jm_network/jm_network.dart
+++ b/lib/network/jm_network/jm_network.dart
@@ -499,13 +499,10 @@ class JmNetwork {
 
   Future<Res<List<JmComicBrief>>> searchNew(
       String keyword, int page, ComicsOrder order) async {
-    appdata.searchHistory.remove(keyword);
-    appdata.searchHistory.add(keyword);
     keyword = keyword.trim();
     keyword = keyword.replaceAll('  ', ' ');
     keyword = Uri.encodeComponent(keyword);
     keyword = keyword.replaceAll('%20', '+');
-    appdata.writeHistory();
     Res res;
     if (page != 1) {
       res = await get(

--- a/lib/network/nhentai_network/nhentai_main_network.dart
+++ b/lib/network/nhentai_network/nhentai_main_network.dart
@@ -174,11 +174,6 @@ class NhentaiNetwork {
 
   Future<Res<List<NhentaiComicBrief>>> search(String keyword, int page,
       [NhentaiSort sort = NhentaiSort.recent]) async {
-    if (appdata.searchHistory.contains(keyword)) {
-      appdata.searchHistory.remove(keyword);
-    }
-    appdata.searchHistory.add(keyword);
-    appdata.writeHistory();
     var res = await get(
         "$baseUrl/search/?q=${Uri.encodeComponent(keyword)}&page=$page${sort.value}");
     if (res.error) {

--- a/lib/network/picacg_network/methods.dart
+++ b/lib/network/picacg_network/methods.dart
@@ -280,11 +280,6 @@ class PicacgNetwork {
       {bool addToHistory = false}) async {
     var response = await post('$apiUrl/comics/advanced-search?page=$page',
         {"keyword": keyWord, "sort": sort});
-    if (page == 1 && addToHistory && keyWord != "") {
-      appdata.searchHistory.remove(keyWord);
-      appdata.searchHistory.add(keyWord);
-      appdata.writeHistory();
-    }
     if (response.error) {
       return Res(null, errorMessage: response.errorMessage);
     }

--- a/lib/pages/comic_page.dart
+++ b/lib/pages/comic_page.dart
@@ -1077,7 +1077,24 @@ abstract class BaseComicPage<T extends Object> extends StatelessWidget {
           PopupMenuItem(
             child: Text("屏蔽".tl),
             onTap: () {
-              appdata.blockingKeyword.add(text);
+              // 根据漫画源类型添加到不同的屏蔽关键词分区
+              if (sourceKey == "jm") {
+                // 禁漫天堂漫画源，添加到禁漫天堂专用分区
+                if (!appdata.jmBlockingKeyword.contains(text)) {
+                  appdata.jmBlockingKeyword.add(text);
+                  showToast(message: "已添加到禁漫天堂屏蔽关键词".tl);
+                } else {
+                  showToast(message: "禁漫天堂屏蔽关键词已存在".tl);
+                }
+              } else {
+                // 其他漫画源，添加到通用分区
+                if (!appdata.blockingKeyword.contains(text)) {
+                  appdata.blockingKeyword.add(text);
+                  showToast(message: "已添加到通用屏蔽关键词".tl);
+                } else {
+                  showToast(message: "通用屏蔽关键词已存在".tl);
+                }
+              }
               appdata.writeData();
             },
           ),

--- a/lib/pages/pre_search_page.dart
+++ b/lib/pages/pre_search_page.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:pica_comic/base.dart';
 import 'package:pica_comic/comic_source/comic_source.dart';
 import 'package:pica_comic/components/components.dart';
+import 'package:pica_comic/foundation/history.dart';
 import 'package:pica_comic/foundation/app.dart';
 import 'package:pica_comic/foundation/pair.dart';
-import 'package:pica_comic/foundation/ui_mode.dart';
 import 'package:pica_comic/pages/comic_page.dart';
 import 'package:pica_comic/pages/search_result_page.dart';
 import 'package:pica_comic/tools/app_links.dart';
@@ -176,6 +176,8 @@ class PreSearchPage extends StatelessWidget {
 
   void search([String? s, String? type]) {
     var keyword = (s ?? controller.text).trim();
+
+    HistoryManager.addSearchHistory(keyword);
 
     if (searchController.language != null &&
         searchController.searchPageData.enableLanguageFilter) {

--- a/lib/pages/settings/blocking_keyword_page.dart
+++ b/lib/pages/settings/blocking_keyword_page.dart
@@ -2,148 +2,204 @@ part of pica_settings;
 
 class BlockingKeywordPageLogic extends StateController {
   var keywords = appdata.blockingKeyword;
+  var jmKeywords = appdata.jmBlockingKeyword;
   bool down = true;
   final controller = TextEditingController();
+  int currentTab = 0;
+
+  void changeTab(int index) {
+    currentTab = index;
+    update();
+  }
+
+  List<String> get currentKeywords => currentTab == 0 ? keywords : jmKeywords;
+
+  void addKeyword() {
+    final keyword = controller.text;
+    if (keyword.isEmpty || currentKeywords.contains(keyword)) {
+      controller.clear();
+      return;
+    }
+    currentKeywords.add(keyword);
+    controller.clear();
+    update();
+    appdata.writeData();
+  }
+
+  void removeKeyword(String keyword) {
+    currentKeywords.remove(keyword);
+    update();
+    appdata.writeData();
+  }
+
+  void toggleOrder() {
+    down = !down;
+    update();
+  }
+
+  void dismissBanner() {
+    appdata.firstUse[0] = "0";
+    appdata.writeData();
+    update();
+  }
 }
 
-class BlockingKeywordPage extends StatelessWidget {
-  BlockingKeywordPage({this.popUp = false, Key? key}) : super(key: key) {
-    StateController.put(BlockingKeywordPageLogic());
-  }
+class BlockingKeywordPage extends StatefulWidget {
+  const BlockingKeywordPage({this.popUp = false, Key? key}) : super(key: key);
 
   final bool popUp;
 
   @override
-  Widget build(BuildContext context) {
-    var addButton = Tooltip(
-      message: "添加".tl,
-      child: IconButton(
-        icon: const Icon(Icons.add),
-        onPressed: () {
-          showDialog(
-            context: context,
-            builder: (dialogContext) => StateBuilder<BlockingKeywordPageLogic>(
-              builder: (logic) => SimpleDialog(
-                title: Text("添加屏蔽关键词".tl),
-                children: [
-                  const SizedBox(
-                    width: 300,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                        vertical: 12, horizontal: 16),
-                    child: TextField(
-                      controller: logic.controller,
-                      decoration: InputDecoration(
-                          border: const OutlineInputBorder(),
-                          hintText: "添加关键词".tl),
-                      onEditingComplete: () {
-                        if (logic.controller.text == "") return;
-                        appdata.blockingKeyword.add(logic.controller.text);
-                        logic.update();
-                        App.globalBack();
-                        logic.controller.text = "";
-                        appdata.writeData();
-                      },
-                    ),
-                  ),
-                  const SizedBox(
-                    height: 8,
-                  ),
-                  Center(
-                    child: FilledButton(
-                      child: Text("提交".tl),
-                      onPressed: () {
-                        if (logic.controller.text == "") return;
-                        appdata.blockingKeyword.add(logic.controller.text);
-                        logic.update();
-                        App.globalBack();
-                        logic.controller.text = "";
-                        appdata.writeData();
-                      },
-                    ),
-                  )
-                ],
+  State<BlockingKeywordPage> createState() => _BlockingKeywordPageState();
+}
+
+class _BlockingKeywordPageState extends State<BlockingKeywordPage>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+  final logic = StateController.put(BlockingKeywordPageLogic());
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
+      length: 2,
+      initialIndex: logic.currentTab,
+      vsync: this,
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _showAddKeywordDialog() {
+    logic.controller.clear();
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return SimpleDialog(
+          title: Text("添加屏蔽关键词".tl),
+          children: [
+            const SizedBox(width: 300),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+              child: TextField(
+                controller: logic.controller,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: "添加关键词".tl,
+                ),
+                onEditingComplete: () {
+                  logic.addKeyword();
+                  App.globalBack();
+                },
               ),
             ),
-          );
-        },
-      ),
+            const SizedBox(height: 8),
+            Center(
+              child: FilledButton(
+                child: Text("提交".tl),
+                onPressed: () {
+                  logic.addKeyword();
+                  App.globalBack();
+                },
+              ),
+            )
+          ],
+        );
+      },
     );
+  }
 
-    var orderButton = StateBuilder<BlockingKeywordPageLogic>(
+  @override
+  Widget build(BuildContext context) {
+    return StateBuilder<BlockingKeywordPageLogic>(
       builder: (logic) {
-        return Tooltip(
+        if (_tabController.index != logic.currentTab) {
+          _tabController.animateTo(logic.currentTab);
+        }
+
+        final addButton = Tooltip(
+          message: "添加".tl,
+          child: IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: _showAddKeywordDialog,
+          ),
+        );
+
+        final orderButton = Tooltip(
           message: "显示顺序",
           child: IconButton(
             icon: logic.down
                 ? const Icon(Icons.arrow_downward)
                 : const Icon(Icons.arrow_upward),
-            onPressed: () {
-              logic.down = !logic.down;
-              logic.update();
-            },
+            onPressed: logic.toggleOrder,
+          ),
+        );
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text("关键词屏蔽".tl),
+            actions: [addButton, orderButton],
+            bottom: TabBar(
+              controller: _tabController,
+              tabs: [
+                Tab(text: "通用".tl),
+                Tab(text: "禁漫天堂".tl),
+              ],
+              onTap: logic.changeTab,
+            ),
+          ),
+          body: TabBarView(
+            controller: _tabController,
+            physics: const NeverScrollableScrollPhysics(),
+            children: [
+              _buildKeywordList(logic, logic.keywords),
+              _buildKeywordList(logic, logic.jmKeywords),
+            ],
           ),
         );
       },
     );
+  }
 
-    var widget = StateBuilder<BlockingKeywordPageLogic>(builder: (logic) {
-      var keywords = logic.down
-          ? appdata.blockingKeyword
-          : appdata.blockingKeyword.reversed.toList();
-      return ListView.builder(
-        itemCount: keywords.length + 1,
-        padding: EdgeInsets.zero,
-        itemBuilder: (context, index) {
-          if (index == 0) {
-            return appdata.firstUse[0] == "1"
-                ? MaterialBanner(
-                    forceActionsBelow: true,
-                    padding: const EdgeInsets.all(15),
-                    leading: Icon(
-                      Icons.info_outline,
-                      color: Theme.of(context).colorScheme.primary,
-                      size: 30,
-                    ),
-                    content:
-                        Text("关键词屏蔽不会生效于收藏夹和历史记录, 屏蔽的依据仅限加载漫画列表时能够获取到的信息".tl),
-                    actions: [
-                        TextButton(
-                            onPressed: () {
-                              appdata.firstUse[0] = "0";
-                              appdata.writeData();
-                              logic.update();
-                            },
-                            child: const Text("关闭"))
-                      ])
-                : const SizedBox(
-                    height: 0,
-                  );
-          } else {
-            return ListTile(
-              title: Text(keywords[index - 1]),
+  Widget _buildKeywordList(
+      BlockingKeywordPageLogic logic, List<String> keywords) {
+    final showBanner =
+        identical(keywords, logic.keywords) && appdata.firstUse[0] == "1";
+
+    final keywordList = logic.down ? keywords : keywords.reversed.toList();
+
+    return ListView(
+      children: [
+        if (showBanner)
+          MaterialBanner(
+            forceActionsBelow: true,
+            padding: const EdgeInsets.all(15),
+            leading: Icon(
+              Icons.info_outline,
+              color: Theme.of(context).colorScheme.primary,
+              size: 30,
+            ),
+            content:
+                Text("关键词屏蔽不会生效于收藏夹和历史记录, 屏蔽的依据仅限加载漫画列表时能够获取到的信息".tl),
+            actions: [
+              TextButton(
+                onPressed: logic.dismissBanner,
+                child: const Text("关闭"),
+              )
+            ],
+          ),
+        ...keywordList.map((keyword) => ListTile(
+              title: Text(keyword),
               trailing: IconButton(
-                icon: Icon(
-                  Icons.close,
-                  color: Theme.of(context).colorScheme.secondary,
-                ),
-                onPressed: () {
-                  logic.keywords.remove(keywords[index - 1]);
-                  logic.update();
-                  appdata.writeData();
-                },
+                icon: const Icon(Icons.delete),
+                onPressed: () => logic.removeKeyword(keyword),
               ),
-            );
-          }
-        },
-      );
-    });
-
-    return PopUpWidgetScaffold(
-      title: "关键词屏蔽".tl,
-      body: widget,
-      tailing: [addButton, orderButton],
+            )),
+      ],
     );
   }
 }

--- a/lib/pages/settings/explore_settings.dart
+++ b/lib/pages/settings/explore_settings.dart
@@ -40,8 +40,7 @@ Widget buildExploreSettings(BuildContext context, bool popUp) {
       ),
       NewPageSetting(
           title: "关键词屏蔽".tl,
-          onTap: () => showPopUpWidget(context,
-              BlockingKeywordPage(popUp: MediaQuery.of(context).size.width>600,)),
+          onTap: () => App.to(context, () => const BlockingKeywordPage()),
           icon: const Icon(Icons.block)
       ),
       SwitchSetting(


### PR DESCRIPTION
为JM添加了专属的关键词屏蔽分区，会在搜索时通过JM的规范（ -xxx）添加在关键词最后，以实现屏蔽效果。
修复了添加了语言筛选的搜索记录会被添加的问题。
（所以到底是谁在network写的searchHistory.add害我找了半天