### PR TITLE
Fix multiple bugs: favorite download null error, duplicate counting, search subtitle, multi-select display, UI overlap

### DIFF
--- a/lib/foundation/local_favorites.dart
+++ b/lib/foundation/local_favorites.dart
@@ -144,7 +144,9 @@ class FavoriteItem {
       : name = comic.title,
         author = comic.uploader,
         type = FavoriteType.ehentai,
-        tags = comic.tags,
+        tags = comic.subTitle.isNotEmpty
+            ? [comic.subTitle, ...comic.tags]
+            : comic.tags,
         target = comic.link,
         coverPath = comic.coverPath;
 
@@ -648,13 +650,24 @@ class LocalFavoritesManager {
 
   List<FolderSync> get folderSync => _getFolderSyncWithDB();
 
-  /// 获取所有文件夹中的漫画总数
+  /// 获取所有文件夹中的漫画总数（去重统计）
+  /// 
+  /// 使用 Set 来确保同一漫画存在于多个文件夹中时只统计一次
   int get totalComics {
-    int total = 0;
+    var uniqueComics = <String>{};
     for (var folder in folderNames) {
-      total += count(folder);
+      // 检查表是否存在
+      final tables = _getTablesWithDB();
+      if (!tables.contains(folder)) {
+        continue;
+      }
+
+      var comics = _db.select('select target, type from "$folder";');
+      for (var comic in comics) {
+        uniqueComics.add('${comic["target"]}_${comic["type"]}');
+      }
     }
-    return total;
+    return uniqueComics.length;
   }
 
   /// 获取指定文件夹中的漫画数量

--- a/lib/network/eh_network/eh_models.dart
+++ b/lib/network/eh_network/eh_models.dart
@@ -14,8 +14,10 @@ class EhGalleryBrief extends BaseComic{
   @override
   List<String> tags;
   int? pages;
+  String _subTitle;
 
-  EhGalleryBrief(this.title,this.type,this.time,this.uploader,this.coverPath,this.stars,this.link,this.tags, {this.pages});
+  EhGalleryBrief(this.title,this.type,this.time,this.uploader,this.coverPath,this.stars,this.link,this.tags, {this.pages, String? subTitle})
+      : _subTitle = subTitle ?? uploader;
 
   @override
   String get cover => coverPath;
@@ -27,7 +29,9 @@ class EhGalleryBrief extends BaseComic{
   String get id => link;
 
   @override
-  String get subTitle => uploader;
+  String get subTitle => _subTitle;
+
+  set subTitle(String value) => _subTitle = value;
 
   @override
   bool get enableTagsTranslation => true;
@@ -95,6 +99,7 @@ class Gallery with HistoryMixin{
       stars,
       link,
       _generateTags(),
+      subTitle: subTitle,
   );
 
   Map<String, dynamic> toJson() {

--- a/lib/network/favorite_download.dart
+++ b/lib/network/favorite_download.dart
@@ -26,12 +26,17 @@ class FavoriteDownloading extends DownloadingItem{
 
   FavoriteItem comic;
 
-  late DownloadingItem downloadLogic;
+  DownloadingItem? downloadLogic;
 
   @override
   void start() async{
-    await onStart();
-    downloadLogic.start();
+    try {
+      await onStart();
+      downloadLogic?.start();
+    } catch (e, s) {
+      Log.error("Download", "Failed to start favorite download: $e$s");
+      onError?.call();
+    }
   }
 
   @override
@@ -87,15 +92,15 @@ class FavoriteDownloading extends DownloadingItem{
     }
     pause();
     DownloadManager().downloading.removeFirst();
-    DownloadManager().downloading.addFirst(downloadLogic);
-    downloadLogic.start();
+    DownloadManager().downloading.addFirst(downloadLogic!);
+    downloadLogic!.start();
   }
 
   @override
   String get cover => comic.coverPath;
 
   @override
-  Future<Map<int, List<String>>> getLinks() => downloadLogic.getLinks();
+  Future<Map<int, List<String>>> getLinks() => downloadLogic?.getLinks() ?? Future.value({});
 
   @override
   String get title => comic.name;
@@ -117,11 +122,19 @@ class FavoriteDownloading extends DownloadingItem{
         super.fromMap(json, whenFinish, whenError, updateInfo);
 
   @override
-  FutureOr<DownloadedItem> toDownloadedItem() =>
-      downloadLogic.toDownloadedItem();
+  FutureOr<DownloadedItem> toDownloadedItem() {
+    if (downloadLogic == null) {
+      throw StateError("Download logic is not initialized. "
+          "This may happen when the download failed to start.");
+    }
+    return downloadLogic!.toDownloadedItem();
+  }
 
   @override
   Future<Stream<DownloadProgress>> downloadImage(String link) async {
-    return downloadLogic.downloadImage(link);
+    if (downloadLogic == null) {
+      throw StateError("Download logic is not initialized");
+    }
+    return downloadLogic!.downloadImage(link);
   }
 }

--- a/lib/pages/download_page.dart
+++ b/lib/pages/download_page.dart
@@ -1487,7 +1487,9 @@ class _DownloadPageState extends State<DownloadPage> {
           (logic.comics[index] as DownloadedComic).comicItem.categories;
     }
 
+    // Fix Issue #21: Add ValueKey to prevent widget reuse causing incorrect selection display
     return Padding(
+      key: ValueKey('download_item_${logic.comics[index].id}'),
       padding: const EdgeInsets.all(2),
       child: Container(
         decoration: BoxDecoration(

--- a/lib/pages/favorites/network_favorites_page.dart
+++ b/lib/pages/favorites/network_favorites_page.dart
@@ -106,16 +106,17 @@ class _NormalFavoritePageState extends State<_NormalFavoritePage> {
         Positioned.fill(
           child: _NormalFavoriteComicsPage(widget.data, showFolders),
         ),
+        // Fix Issue #81: Move random button to left-bottom to avoid overlapping with pagination controls
         if (widget.data.key == 'nhentai')
           Positioned(
-            right: 16,
+            left: 16,
             bottom:
                 MediaQuery.of(context).padding.bottom +
                 bottomOverlayInsetOf(context) +
                 16,
             child: Tooltip(
               message: '随机'.tl,
-              child: FloatingActionButton(
+              child: FloatingActionButton.small(
                 heroTag: 'network_fav_random_${widget.data.key}',
                 onPressed: openRandomFavorite,
                 child: const Icon(Icons.shuffle),
@@ -713,4 +714,4 @@ class _FavoriteFolderComicsPage extends ComicsPage<BaseComic> {
       ),
     );
   }
-} 
+}


### PR DESCRIPTION
## Bug Fixes

This PR fixes 5 bugs reported in the Issues section:

### 1. Fix Issue #66 - 收藏夹长按多选下载空指针异常 (Null check operator on null value)
**File:** `lib/network/favorite_download.dart`
**Problem:** `downloadLogic` was declared as `late DownloadingItem` but could remain uninitialized if `onStart()` encountered an exception, causing `LateInitializationError`.
**Fix:**
- Changed `downloadLogic` from `late` to nullable `DownloadingItem?`
- Added null-safe checks in `start()`, `getLinks()`, `toDownloadedItem()`, and `downloadImage()`
- Added try-catch in `start()` to prevent crashes when download initialization fails
- Provides clear error message when download logic is not initialized

### 2. Fix Issue #71 - 收藏夹漫画总数量统计逻辑存在问题 (Duplicate counting)
**File:** `lib/foundation/local_favorites.dart`
**Problem:** `totalComics` getter used simple addition of all folder counts, causing the same comic (if in multiple folders) to be counted multiple times.
**Fix:**
- `totalComics` now uses a `Set<String>` to deduplicate comics across all folders
- Each comic is uniquely identified by a `"${target}_${type}"` composite key
- Ensures accurate count of unique comics regardless of folder organization

### 3. Fix Issue #32 - ehentai 本地收藏的漫画副标题搜索不到
**Files:** `lib/network/eh_network/eh_models.dart`, `lib/foundation/local_favorites.dart`
**Problem:** `EhGalleryBrief.subTitle` always returned `uploader` instead of the actual Japanese subtitle. When adding to favorites, the subtitle information was lost, making it impossible to search by subtitle keyword.
**Fix:**
- Added `_subTitle` field to `EhGalleryBrief` with proper getter/setter
- Modified `Gallery.toBrief()` to pass the actual `subTitle` to `EhGalleryBrief`
- Modified `FavoriteItem.fromEhentai()` to store the subtitle in the tags list, enabling subtitle-based search

### 4. Fix Issue #21 - 已下载漫画多选显示异常
**File:** `lib/pages/download_page.dart`
**Problem:** When multi-selecting downloaded comics, the selection highlight display was inconsistent due to Flutter widget reuse (missing keys in `SliverChildBuilderDelegate`).
**Fix:**
- Added `ValueKey('download_item_${logic.comics[index].id}')` to each grid item
- Ensures Flutter correctly tracks widget identity and renders selection state accurately

### 5. Fix Issue #81 - nhentai 收藏夹 UI 按钮遮挡
**File:** `lib/pages/favorites/network_favorites_page.dart`
**Problem:** The random (shuffle) FAB in the bottom-right corner overlapped with the pagination "前进" button.
**Fix:**
- Moved the random FAB from `right: 16` to `left: 16` (bottom-left corner)
- Changed from `FloatingActionButton` to `FloatingActionButton.small` for a less obtrusive appearance
- Eliminates overlap with pagination controls at the bottom

---

All changes are minimal and focused on fixing the specific bugs without introducing new features or breaking existing functionality.